### PR TITLE
Updated ALPHA_SCISSOR_THRESHOLD with alpha_cutoff value

### DIFF
--- a/demo/shaders/cel-shader-aniso.gdshader
+++ b/demo/shaders/cel-shader-aniso.gdshader
@@ -80,7 +80,7 @@ void fragment() {
 	ALBEDO *= alpha;
 #elif USE_ALPHA_CUTOFF
 	ALPHA = color.a * texture(base_texture, UV).a;
-	ALPHA_SCISSOR_THRESHOLD = color.a * texture(base_texture, UV).a;
+	ALPHA_SCISSOR_THRESHOLD = alpha_cutoff;
 #endif
 	
 #if USE_REFRACTION && USE_ALPHA

--- a/demo/shaders/cel-shader-base.gdshader
+++ b/demo/shaders/cel-shader-base.gdshader
@@ -80,7 +80,7 @@ void fragment() {
 	ALBEDO *= alpha;
 #elif USE_ALPHA_CUTOFF
 	ALPHA = color.a * texture(base_texture, UV).a;
-	ALPHA_SCISSOR_THRESHOLD = color.a * texture(base_texture, UV).a;
+	ALPHA_SCISSOR_THRESHOLD = alpha_cutoff;
 #endif
 
 #if USE_REFRACTION && USE_ALPHA

--- a/demo/shaders/cel-shader-translucent.gdshader
+++ b/demo/shaders/cel-shader-translucent.gdshader
@@ -80,7 +80,7 @@ void fragment() {
 	ALBEDO *= alpha;
 #elif USE_ALPHA_CUTOFF
 	ALPHA = color.a * texture(base_texture, UV).a;
-	ALPHA_SCISSOR_THRESHOLD = color.a * texture(base_texture, UV).a;
+	ALPHA_SCISSOR_THRESHOLD = alpha_cutoff;
 #endif
 	
 #if USE_REFRACTION && USE_ALPHA

--- a/demo/shaders/cel-shader-transp.gdshader
+++ b/demo/shaders/cel-shader-transp.gdshader
@@ -80,7 +80,7 @@ void fragment() {
 	ALBEDO *= alpha;
 #elif USE_ALPHA_CUTOFF
 	ALPHA = color.a * texture(base_texture, UV).a;
-	ALPHA_SCISSOR_THRESHOLD = color.a * texture(base_texture, UV).a;
+	ALPHA_SCISSOR_THRESHOLD = alpha_cutoff;
 #endif
 	
 #if USE_REFRACTION && USE_ALPHA


### PR DESCRIPTION
I have tested this locally with my own project, and can verify that when you slide the alpha_cutoff value it will adjust when the alpha value is applied.

<img width="1992" height="858" alt="Godot_v4 5 1-stable_win64_GBFJh8PmWQ" src="https://github.com/user-attachments/assets/31224bdc-8254-4759-8491-5edd22f214a8" />

<img width="1255" height="667" alt="image" src="https://github.com/user-attachments/assets/f4dc8ac5-fbcf-4ca5-9ac8-68078ede4a8a" />
